### PR TITLE
setup: Fix build in mingw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,7 @@ jobs:
           pacboy: cc:p python:p python-setuptools:p python-sphinx:p
       - name: Build
         run: CC=cc python setup.py build
+      - name: Check
+        run: |
+          CC=cc python setup.py build_ext --inplace
+          python -c "import winkerberos;print(winkerberos.__version__)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  windows-msys2:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
+    name: Build (${{ matrix.msystem }})
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          pacboy: cc:p python:p python-setuptools:p python-sphinx:p
+      - name: Build
+        run: CC=cc python setup.py build

--- a/setup.py
+++ b/setup.py
@@ -89,20 +89,17 @@ with open("README.rst") as f:
 
 tests_require = ["pymongo >= 2.9"]
 
-chost = os.environ.get("MINGW_CHOST") #ie: i686-w64-mingw32
-if chost:
-    #mingw build
-    libpath = os.environ.get("MINGW_PREFIX", "/mingw32")+"/"+chost+"/lib"
-    extra_link_args = ["-lssl", "-lcrypto", "-fPIC",
-        "%s/libcrypt32.a" % libpath,
-        "%s/libsecur32.a" % libpath,
-        "%s/libshlwapi.a" % libpath,
-        ]
-else:
+if 'MSC' in sys.version:
     #msvc:
     extra_link_args = ['crypt32.lib', 'secur32.lib', 'Shlwapi.lib',
            '/NXCOMPAT', '/DYNAMICBASE',
            ]
+else:
+    #mingw:
+    extra_link_args = ['-lcrypt32',
+                        '-lsecur32',
+                        '-lshlwapi']
+
 setup(
     name="winkerberos",
     version="0.8.0",

--- a/src/kerberos_sspi.h
+++ b/src/kerberos_sspi.h
@@ -21,13 +21,6 @@
 #include <Windows.h>
 #include <sspi.h>
 
-#ifdef __MINGW32__
-typedef struct _SecPkgContext_Bindings {
-  unsigned long        BindingsLength;
-  SEC_CHANNEL_BINDINGS *Bindings;
-} SecPkgContext_Bindings, *PSecPkgContext_Bindings;
-#endif
-
 #define AUTH_GSS_ERROR -1
 #define AUTH_GSS_COMPLETE 1
 #define AUTH_GSS_CONTINUE 0


### PR DESCRIPTION
MINGW_CHOST is specific to msys2 build and packaging environment.
Instead, check sys.version which is available in any python env.
Also remove SecPkgContext_Bindings definition which has been added
in mingw-w64 headers.