### PR TITLE
None for authGSSClientStep's channel_bindings

### DIFF
--- a/src/winkerberos.c
+++ b/src/winkerberos.c
@@ -746,7 +746,7 @@ sspi_client_step(PyObject* self, PyObject* args, PyObject* keywds) {
         return NULL;
     }
 
-    if (pychan_bindings != NULL) {
+    if (pychan_bindings != NULL && pychan_bindings != Py_None) {
         if (!PyCapsule_CheckExact(pychan_bindings)) {
             PyErr_SetString(PyExc_TypeError, "Expected a channel bindings object");
             return NULL;


### PR DESCRIPTION
Allows authGSSClientStep(ctx, token, channel_bindings=None)
See #49  for details