### PR TITLE
PYTHON-4417 Add missing step for publish job

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -85,6 +85,7 @@ jobs:
       id-token: write
       contents: write
     steps:
+    - uses: actions/checkout@v4
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
"/bin/bash: /home/runner/work/winkerberos/winkerberos/scripts/generate-signatures.sh: No such file or directory"

https://github.com/mongodb/winkerberos/actions/runs/8926048456/job/24516383509