### PR TITLE
PYTHON-4417 Fix publish action

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -83,8 +83,8 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
       run: |
         echo "$GITHUB_RUN_ID" > release_run_id.txt
-        gh release create ${{ github.ref_name }} --draft --verify-tag --title ${{ github.ref_name }} --notes ""
-        gh release upload ${{ github.ref_name }} signatures/*.sig
+        gh release create ${{ inputs.version }} --draft --verify-tag --title ${{ inputs.version }} --notes ""
+        gh release upload ${{ inputs.version }} signatures/*.sig
         gh release upload ${{ inputs.version }} release_run_id.txt
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
     - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
Alllmost there...

`tag master doesn't exist in the repo mongodb/winkerberos, aborting due to --verify-tag flag`