### PR TITLE
PYTHON-4417 Fix post release action

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
+    - uses: actions/checkout@v4
     - name: Download the metadata and upload the logs
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`failed to run git: fatal: not a git repository (or any of the parent directories): .git`

https://github.com/mongodb/winkerberos/actions/runs/9037467455/job/24836559531