### PR TITLE
PYTHON-5188 Make version setting a part of the release process

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "The new version to set"
-        required: true
       following_version:
         description: "The post (dev) version to set"
         required: false
@@ -26,7 +23,7 @@ env:
   # to 'false' when the input is set to 'false'.
   DRY_RUN: ${{ ! contains(inputs.dry_run, 'false') }}
   FOLLOWING_VERSION: ${{ inputs.following_version || '' }}
-  VERSION: ${{ inputs.version || '10.10.10.10' }}
+  VERSION: ${{ github.event_name == 'schedule' && '10.10.10.10' || '' }}
 
 defaults:
   run:


### PR DESCRIPTION
But preserve the handling of version in the nightly tests.