### PR TITLE
PYTHON-5971 Avoid using TestPyPI in release process

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -66,6 +66,11 @@ jobs:
           # Build sdist on lowest supported Python
           python-version: '3.10'
 
+      - name: Validate pyproject.toml
+        run: |
+          pip install 'validate-pyproject[all]'
+          validate-pyproject pyproject.toml
+
       - name: Build SDist
         run: |
           pip install check-manifest build
@@ -89,6 +94,13 @@ jobs:
         run: |
           find . -mindepth 2 -type f -exec mv {} . \;
           find . -type d -empty -delete
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+      - name: Check dist metadata
+        run: |
+          pip install twine
+          twine check --strict *.whl *.tar.gz
       - uses: actions/upload-artifact@v7
         with:
           name: all-dist-${{ github.run_id }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -81,12 +81,6 @@ jobs:
         with:
           name: all-dist-${{ github.run_id }}
           path: dist/
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          attestations: ${{ env.DRY_RUN }}
       - name: Publish package distributions to PyPI
         if: startsWith(env.DRY_RUN, 'false')
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
## Summary
- Remove the "Publish package distributions to TestPyPI" step from the release workflow; PyPI admins are deprecating/de-prioritizing TestPyPI, and it previously broke nightly uploads by rejecting downloads of artifacts older than 14 days.
- Add local validation instead, matching the approach already used for PyMongo in PYTHON-5970: `validate-pyproject pyproject.toml` in the sdist build job, and `twine check --strict` against the collected wheels/sdist before upload.

## Test plan
- [x] `pre-commit run --all-files` (workflow YAML validation, codespell, etc.) passes
- [x] Manually trigger the Release workflow with `dry_run: true` and confirm it builds, validates, and stops without publishing anywhere — [run 32150166677](https://github.com/mongodb/winkerberos/actions/runs/32150166677), all jobs passed
