### PR TITLE
Pin first-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v7.0.1
+     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
        with:
         persist-credentials: false
         # Lowest supported Python
         python-version: '3.10'
-     - uses: actions/setup-python@v7
+     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
        with:
          extra_args: --all-files --hook-stage manual
@@ -32,10 +32,10 @@ jobs:
   docs:
     runs-on: windows-latest
     steps:
-     - uses: actions/checkout@v7.0.1
+     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
        with:
         persist-credentials: false
-     - uses: actions/setup-python@v7
+     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
        with:
         # Lowest supported Python
         python-version: '3.10'
@@ -56,7 +56,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
@@ -79,11 +79,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,11 +37,11 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
-    - uses: actions/setup-python@v7
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         # Lowest supported Python
         python-version: '3.10'

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         buildplat: ["win_amd64", "win32"]
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
           ls wheelhouse/*cp313*.whl
           ls wheelhouse/*cp314*.whl
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.buildplat }}
           path: ./wheelhouse/*.whl
@@ -56,12 +56,12 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           # Build sdist on lowest supported Python
           python-version: '3.10'
@@ -72,7 +72,7 @@ jobs:
           check-manifest -v
           python -m build --sdist .
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "sdist"
           path: dist/*.tar.gz
@@ -83,13 +83,13 @@ jobs:
     name: Download Wheels
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Flatten directory
         working-directory: .
         run: |
           find . -mindepth 2 -type f -exec mv {} . \;
           find . -type d -empty -delete
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: all-dist-${{ github.run_id }}
           path: "./*"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -77,7 +77,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: all-dist-${{ github.run_id }}
           path: dist/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Run zizmor 🌈


### PR DESCRIPTION
## Summary
A Semgrep review on #161 flagged `actions/setup-python@v7` as a mutable tag that could be repointed to run untrusted code. The same tag-based pinning was already used for every first-party `actions/*` step in this repo, while third-party actions (`pypa/cibuildwheel`, `pypa/gh-action-pypi-publish`) were already pinned to commit SHAs — so this closes the gap consistently rather than just on the one flagged line.

## Motivation
A movable version tag (`v7`, `v8`) can be repointed by the action owner (or anyone who compromises that repo) to a different commit, letting a workflow silently run different code than what was reviewed. Pinning to a commit SHA removes that risk.

## Changes
- Pinned `actions/checkout@v7.0.1` to its commit SHA across `codeql.yml`, `dist.yml`, `build.yml`, and `zizmor.yml`.
- Pinned `actions/setup-python@v7` (resolved to v7.0.0) to its commit SHA across `codeql.yml`, `dist.yml`, and `build.yml`.
- Pinned `actions/upload-artifact@v7` (resolved to v7.0.1) to its commit SHA in `dist.yml`.
- Pinned `actions/download-artifact@v8` (resolved to v8.0.1) to its commit SHA in `dist.yml` and `release-python.yml`.
- Each pin keeps a `# vX.Y.Z` comment noting the version, matching the existing convention for third-party actions.

## Testing
- Verified each commit SHA against the corresponding tag via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` before using it.
- `git commit` ran the repo's pre-commit hooks, including the "Validate GitHub Workflows" check — all passed.
- Confirmed all five workflow YAML files still parse (`yaml.safe_load`).